### PR TITLE
Ativo adjacente payoff

### DIFF
--- a/src/blackscholes/payoff.py
+++ b/src/blackscholes/payoff.py
@@ -65,6 +65,70 @@ def payoff_com_premio(legs, S_range):
     return payoff_dict
 
 
+
+def payoff_com_premio_new(legs, S_range):
+    """
+    Calcula o payoff líquido de uma estrutura de opções usando prêmios já conhecidos.
+    Agora inclui também o ativo adjacente tratado como um leg.
+    """
+    payoff_dict = {}
+    custo_inicial = 0
+
+    # custo inicial = prêmios pagos/recebidos (opções + ativo)
+    for leg in legs:
+        qtd = leg.get("qtd", 1)
+        sentido = leg["sentido"]
+
+        if leg["tipo"] in ("call", "put"):
+            premio = leg["premio"]
+            if sentido == "C":
+                custo_inicial += premio * qtd
+            elif sentido == "V":
+                custo_inicial -= premio * qtd
+
+        elif leg["tipo"] == "ativo":
+            # ativo pode ter prêmio inicial (se existir custo de carregar, ex: ajuste futuro)
+            premio = leg.get("premio", 0)
+            if sentido == "C":
+                custo_inicial += premio * qtd
+            elif sentido == "V":
+                custo_inicial -= premio * qtd
+
+    # payoff para cada preço final
+    for S_final in S_range:
+        payoff_total = 0
+
+        for leg in legs:
+            qtd = leg.get("qtd", 1)
+            sentido = leg["sentido"]
+
+            if leg["tipo"] == "call":
+                payoff_leg = max(S_final - leg["strike"], 0) * qtd
+                if sentido == "V":
+                    payoff_leg = -payoff_leg
+
+            elif leg["tipo"] == "put":
+                payoff_leg = max(leg["strike"] - S_final, 0) * qtd
+                if sentido == "V":
+                    payoff_leg = -payoff_leg
+
+            elif leg["tipo"] == "ativo":
+                S0 = leg["ativo_adjacente"]
+                payoff_leg = (S_final - S0) * qtd
+                if sentido == "V":
+                    payoff_leg = -payoff_leg
+
+            else:
+                raise ValueError("Tipo deve ser 'call', 'put' ou 'ativo'")
+
+            payoff_total += payoff_leg
+
+        payoff_dict[S_final] = payoff_total - custo_inicial
+
+    return payoff_dict, custo_inicial
+
+
+
 def calcular_break_even(payoff_dict):
     """
     Calcula os pontos de break-even (preço onde payoff cruza zero).
@@ -170,27 +234,18 @@ def calcular_estrutura_api(legs, S_range):
     Gera saída completa para API com nome da estrutura,
     payoff, break-evens e custo inicial.
     """
-
-    # Nome da estrutura (ou 'não reconhecida')
     nome = identificar_estrutura(legs)
 
-    # Calcula payoff e pontos de break-even
-    payoff_dict = payoff_com_premio(legs, S_range)
+    payoff_dict, custo_inicial = payoff_com_premio_new(legs, S_range)
     break_evens = calcular_break_even(payoff_dict)
 
-    # Custo inicial é a diferença entre payoff inicial e payoff bruto
-    custo_inicial = sum(
-        leg["premio"] * (1 if leg["sentido"] == "C" else -1) * leg.get("qtd", 1)
-        for leg in legs
-    )
-
-    # Monta resposta
     return {
         "estrutura": nome,
         "custo_inicial": round(custo_inicial, 2),
         "payoff": {float(k): round(v, 2) for k, v in payoff_dict.items()},
         "break_evens": break_evens,
     }
+
 
 def plot_payoff(payoff_dict, break_evens=None, titulo="Payoff da Estrutura"):
     """

--- a/src/blackscholes/payoff.py
+++ b/src/blackscholes/payoff.py
@@ -68,65 +68,66 @@ def payoff_com_premio(legs, S_range):
 
 def payoff_com_premio_new(legs, S_range):
     """
-    Calcula o payoff líquido de uma estrutura de opções usando prêmios já conhecidos.
-    Agora inclui também o ativo adjacente tratado como um leg.
+    Args:
+        legs: lista de dicionários com as pernas, ex:
+            {"tipo": "ativo", "ativo_adjacente": 100, "sentido": "C", "qtd": 1}
+            {"tipo": "put", "strike": 100, "premio": 10, "sentido": "C", "qtd": 1}
+            {"tipo": "call", "strike": 110, "premio": 10, "sentido": "V", "qtd": 1}
+        S_range: lista de preços do ativo no vencimento (ex: range(70, 140, 5))
+
+    Returns:
+        payoff_dict: {S: payoff_total} para cada preço final
+        custo_inicial: prêmio líquido (ΔP)
     """
     payoff_dict = {}
-    custo_inicial = 0
+    custo_inicial = 0  # soma dos prêmios (Pc - Pp)
 
-    # custo inicial = prêmios pagos/recebidos (opções + ativo)
+    # custo inicial líquido: somatório dos prêmios
     for leg in legs:
         qtd = leg.get("qtd", 1)
-        sentido = leg["sentido"]
-
+        premio = leg.get("premio", 0)
         if leg["tipo"] in ("call", "put"):
-            premio = leg["premio"]
-            if sentido == "C":
-                custo_inicial += premio * qtd
-            elif sentido == "V":
-                custo_inicial -= premio * qtd
+            if leg["sentido"] == "C":
+                custo_inicial -= premio * qtd   # pagou prêmio
+            elif leg["sentido"] == "V":
+                custo_inicial += premio * qtd   # recebeu prêmio
 
-        elif leg["tipo"] == "ativo":
-            # ativo pode ter prêmio inicial (se existir custo de carregar, ex: ajuste futuro)
-            premio = leg.get("premio", 0)
-            if sentido == "C":
-                custo_inicial += premio * qtd
-            elif sentido == "V":
-                custo_inicial -= premio * qtd
-
-    # payoff para cada preço final
-    for S_final in S_range:
+    # payoff em cada preço S no vencimento
+    for S in S_range:
         payoff_total = 0
 
         for leg in legs:
             qtd = leg.get("qtd", 1)
+            tipo = leg["tipo"]
             sentido = leg["sentido"]
 
-            if leg["tipo"] == "call":
-                payoff_leg = max(S_final - leg["strike"], 0) * qtd
-                if sentido == "V":
-                    payoff_leg = -payoff_leg
-
-            elif leg["tipo"] == "put":
-                payoff_leg = max(leg["strike"] - S_final, 0) * qtd
-                if sentido == "V":
-                    payoff_leg = -payoff_leg
-
-            elif leg["tipo"] == "ativo":
+            if tipo == "ativo":
                 S0 = leg["ativo_adjacente"]
-                payoff_leg = (S_final - S0) * qtd
+                payoff_leg = (S - S0) * qtd
                 if sentido == "V":
+                    payoff_leg = -payoff_leg
+
+            elif tipo == "put":
+                strike = leg["strike"]
+                payoff_leg = max(strike - S, 0) * qtd
+                if sentido == "V":  # vendido
+                    payoff_leg = -payoff_leg
+
+            elif tipo == "call":
+                strike = leg["strike"]
+                payoff_leg = -max(S - strike, 0) * qtd
+                if sentido == "C":  # comprado
                     payoff_leg = -payoff_leg
 
             else:
-                raise ValueError("Tipo deve ser 'call', 'put' ou 'ativo'")
+                raise ValueError("Tipo deve ser 'ativo', 'put' ou 'call'")
 
             payoff_total += payoff_leg
 
-        payoff_dict[S_final] = payoff_total - custo_inicial
+        # soma ΔP como constante
+        payoff_dict[S] = payoff_total + custo_inicial
 
     return payoff_dict, custo_inicial
-
 
 
 def calcular_break_even(payoff_dict):

--- a/src/blackscholes/payoff.py
+++ b/src/blackscholes/payoff.py
@@ -1,76 +1,12 @@
 import matplotlib.pyplot as plt
 
+
+
 def payoff_com_premio(legs, S_range):
-    """
-    Calcula o payoff líquido de uma estrutura de opções usando prêmios já conhecidos.
-
-    Args:
-        legs (list[dict]): Lista de dicts com os campos:
-            - tipo: "call" ou "put"
-            - strike: preço de exercício
-            - premio: valor do prêmio (positivo)
-            - sentido: "C" para compra (paga prêmio), "V" para venda (recebe prêmio)
-            - qtd (opcional): quantidade de contratos (default = 1)
-        S_range (list ou np.array): preços simulados do ativo no vencimento
-
-    Returns:
-        dict: {preço_subjacente: payoff_liquido}
-    """
-
-    # Cálculo do custo inicial da estrutura
-    custo_inicial = 0
-    for leg in legs:
-        premio = leg["premio"]
-        qtd = leg.get("qtd", 1)  # default 1 se não informado
-        sentido = leg["sentido"]
-
-        if sentido == "C":  # Compra = paga prêmio
-            custo_inicial += premio * qtd
-        elif sentido == "V":  # Venda = recebe prêmio
-            custo_inicial -= premio * qtd
-        else:
-            raise ValueError("Sentido deve ser 'C' (compra) ou 'V' (venda)")
-
-    # Calcular payoff líquido em cada ponto do S_range
-    payoff_dict = {}
-
-    for S_final in S_range:
-        payoff_total = 0
-        for leg in legs:
-            tipo = leg["tipo"]
-            strike = leg["strike"]
-            qtd = leg.get("qtd", 1)
-            sentido = leg["sentido"]
-
-            # Payoff bruto por tipo
-            if tipo == "call":
-                payoff_leg = max(S_final - strike, 0)
-            elif tipo == "put":
-                payoff_leg = max(strike - S_final, 0)
-            else:
-                raise ValueError("Tipo deve ser 'call' ou 'put'")
-
-            # Multiplicar pela quantidade
-            payoff_leg *= qtd
-
-            # Se for venda, inverte o sinal
-            if sentido == "V":
-                payoff_leg = -payoff_leg
-
-            payoff_total += payoff_leg
-
-        # Lucro líquido = payoff bruto - custo inicial
-        payoff_dict[S_final] = payoff_total - custo_inicial
-
-    return payoff_dict
-
-
-
-def payoff_com_premio_new(legs, S_range):
     """
     Args:
         legs: lista de dicionários com as pernas, ex:
-            {"tipo": "ativo", "ativo_adjacente": 100, "sentido": "C", "qtd": 1}
+            {"tipo": "ativo_adjacente", "premio": 100, "sentido": "C", "qtd": 1}
             {"tipo": "put", "strike": 100, "premio": 10, "sentido": "C", "qtd": 1}
             {"tipo": "call", "strike": 110, "premio": 10, "sentido": "V", "qtd": 1}
         S_range: lista de preços do ativo no vencimento (ex: range(70, 140, 5))
@@ -101,8 +37,8 @@ def payoff_com_premio_new(legs, S_range):
             tipo = leg["tipo"]
             sentido = leg["sentido"]
 
-            if tipo == "ativo":
-                S0 = leg["ativo_adjacente"]
+            if tipo == "ativo_adjacente":
+                S0 = leg["premio"]
                 payoff_leg = (S - S0) * qtd
                 if sentido == "V":
                     payoff_leg = -payoff_leg
@@ -120,7 +56,7 @@ def payoff_com_premio_new(legs, S_range):
                     payoff_leg = -payoff_leg
 
             else:
-                raise ValueError("Tipo deve ser 'ativo', 'put' ou 'call'")
+                raise ValueError("Tipo deve ser 'ativo_adjacente', 'put' ou 'call'")
 
             payoff_total += payoff_leg
 
@@ -237,7 +173,7 @@ def calcular_estrutura_api(legs, S_range):
     """
     nome = identificar_estrutura(legs)
 
-    payoff_dict, custo_inicial = payoff_com_premio_new(legs, S_range)
+    payoff_dict, custo_inicial = payoff_com_premio(legs, S_range)
     break_evens = calcular_break_even(payoff_dict)
 
     return {


### PR DESCRIPTION
### 🧩 Descrição da Mudança

Este PR atualiza o módulo de cálculo de payoff para incluir o leg de ativo adjacente `{"tipo": "ativo_adjacente"}`, permitindo representar posições diretas no ativo base dentro das estratégias compostas por opções.

---

### ⚙️ Principais Alterações

**Novo tipo de leg:**

```python
{"tipo": "ativo_adjacente", "premio": S0, "sentido": "C" ou "V", "qtd": n}
```

**Detalhes:**

- `premio` representa o preço inicial (S₀) do ativo
- `sentido` define a posição:
  - `"C"` → comprado (lucra quando S > S₀)
  - `"V"` → vendido (lucra quando S < S₀)

**Cálculo do Payoff:**

```python
payoff = (S - S0) * qtd
```

Com sinal ajustado conforme o sentido.

**Observações:**

- A estrutura geral da função foi mantida, garantindo compatibilidade com os legs de `call` e `put`
- O `custo_inicial` continua refletindo apenas o somatório líquido dos prêmios pagos/recebidos das opções

---

### 📈 Impacto no Gráfico de Payoff

O gráfico agora reflete o efeito linear do ativo subjacente, permitindo visualizar:

- Estratégias com hedge parcial ou total em ativo
- Estruturas sintéticas (ex.: covered call, protective put)

O ponto de equilíbrio e o formato da curva podem se alterar, já que o payoff total passa a incorporar também a variação direta do ativo.
